### PR TITLE
Extract widget painters

### DIFF
--- a/examples/line_edit/Makefile
+++ b/examples/line_edit/Makefile
@@ -1,5 +1,5 @@
 all:
-	crystal build src/line_edit.cr --link-flags -L/usr/X11R6/lib/
+	crystal build src/line_edit.cr --link-flags -L/usr/X11/lib/
 
 clean:
 	rm line_edit

--- a/examples/line_edit/Makefile
+++ b/examples/line_edit/Makefile
@@ -1,5 +1,5 @@
 all:
-	crystal build src/line_edit.cr --link-flags -L/usr/X11/lib/
+	crystal build src/line_edit.cr --link-flags -L/usr/X11R6/lib/
 
 clean:
 	rm line_edit

--- a/examples/line_edit/src/line_edit.cr
+++ b/examples/line_edit/src/line_edit.cr
@@ -16,7 +16,7 @@ module LineEdit
       push_button.object_name = "push_button"
       push_button.geometry = Rect.new 20, 20, 150, 23
 
-      # Creatiin a LineWdit on the Main Window
+      # Create a LineEdit on the Main Window
       line_edit = LineEdit.new main_win
       line_edit.object_name = "line_edit"
       line_edit.geometry = Rect.new 20, 63, 150, 23

--- a/src/ltk.cr
+++ b/src/ltk.cr
@@ -1,6 +1,7 @@
 require "./ltk/base/*"
 require "./ltk/layout/*"
 require "./ltk/widget/*"
+require "./ltk/widget_painters/*"
 require "./ltk/*"
 
 module Ltk

--- a/src/ltk/base/painter.cr
+++ b/src/ltk/base/painter.cr
@@ -8,7 +8,7 @@ module Ltk
   include Cairo
 
   struct Painter
-    getter font_extents : Cairo::FontExtents
+    getter font_extents : Cairo::FontExtents, ctx : Cairo::Context
     private getter space_width : Float64
 
     def initialize(widget : Widget)
@@ -173,75 +173,6 @@ module Ltk
 
       @ctx.set_source_rgb 0.85_f64, 0.85_f64, 0.85_f64
       @ctx.show_text text
-    end
-
-    def draw_line_edit(line_edit : LineEdit)
-      focused = line_edit.focused?
-      w = line_edit.width
-      h = line_edit.height
-
-      #@ctx.scale 3.0_f64, 3.0_f64
-
-      # Draw Borders
-      if focused
-        @ctx.set_source_rgb 83.0_f64 / 255.0_f64, 160.0_f64 / 255.0_f64, 237.0_f64 / 255.0_f64
-      else
-        pattern = Pattern.create_linear 0.0_f64, 0.0_f64, 0.0_f64, h.to_f
-        pattern.add_color_stop 0.0_f64, 46.0_f64 / 255.0_f64, 46.0_f64 / 255.0_f64, 46.0_f64 / 255.0_f64
-        pattern.add_color_stop 1.0_f64, 60.0_f64 / 255.0_f64, 60.0_f64 / 255.0_f64, 60.0_f64 / 255.0_f64
-        @ctx.source = pattern
-      end
-      fill_round_rect 0, 0, w, h, 3
-
-      w -= 2; h -= 2
-      if focused
-        @ctx.set_source_rgb 48.0_f64 / 255.0_f64, 60.0_f64 / 255.0_f64, 72.0_f64 / 255.0_f64
-      else
-        pattern = Pattern.create_linear 0.0_f64, 0.0_f64, 0.0_f64, h.to_f
-        pattern.add_color_stop 0.0_f64, 50.0_f64 / 255.0_f64, 50.0_f64 / 255.0_f64, 50.0_f64 / 255.0_f64
-        pattern.add_color_stop 1.0_f64, 53.0_f64 / 255.0_f64, 53.0_f64 / 255.0_f64, 53.0_f64 / 255.0_f64
-        @ctx.source = pattern
-      end
-      fill_round_rect 1, 1, w, h, 3
-
-      w -= 2; h -= 2
-      @ctx.set_source_rgb 56.0_f64 / 255.0_f64, 56.0_f64 / 255.0_f64, 56.0_f64 / 255.0_f64
-      fill_round_rect 2, 2, w, h, 3
-
-      # Clip region for text and cursor
-      w = line_edit.width
-      h = line_edit.height
-      @ctx.rectangle(5.0_f64, 0_f64, w - 5.0_f64, h.to_f64)
-      @ctx.clip
-
-      # Draw Text
-      text = line_edit.text
-      text_translate = line_edit.text_translate
-
-      extents = @ctx.text_extents text
-      x = 5.0_f64 + text_translate.x
-      y = (line_edit.height / 2.0_f64) - (@font_extents.height / 2 - @font_extents.ascent) + text_translate.y
-
-      @ctx.move_to x, y
-
-      @ctx.set_source_rgb 0.85_f64, 0.85_f64, 0.85_f64
-      @ctx.show_text text
-
-      # Draw Cursor
-      if line_edit.cursor_visible? && line_edit.cursor_position >= 0
-        extents = @ctx.text_extents text[0...line_edit.cursor_position]
-        x = 5.5_f64 + extents.width
-        @ctx.set_source_rgb 1.0_f64, 1.0_f64, 1.0_f64
-        rect = line_edit.cursor_rect
-        if rect.width > 1
-          puts "rect.width > 0 : #{rect.width}"
-        else
-          @ctx.move_to rect.x.to_f64, 4.0_f64
-          @ctx.line_to rect.x.to_f64, h.to_f64
-          @ctx.line_width = 1.0
-          @ctx.stroke
-        end
-      end
     end
 
     private def apply_brush

--- a/src/ltk/widget/line_edit.cr
+++ b/src/ltk/widget/line_edit.cr
@@ -72,7 +72,7 @@ module Ltk
       end
       key_char = event.key_char
       unless key_char == ::Char::ZERO
-        @text += key_char
+        @text = @text.insert @cursor_position, key_char
         @cursor_position += 1
         recalc_cursor
         repaint

--- a/src/ltk/widget/line_edit.cr
+++ b/src/ltk/widget/line_edit.cr
@@ -94,20 +94,26 @@ module Ltk
     end
 
     protected def paint_event
-      p = Painter.new self
-      p.draw_line_edit self
+      widget_painter.draw
+    end
+
+    private def painter
+      @painter ||= Painter.new self
+    end
+
+    private def widget_painter
+      @widget_painter ||= LineEditPainter.new self, painter
     end
 
     protected def recalc_cursor
-      p = Painter.new self
       w = width
       h = height
       right_bound = w - 5
 
-      text_extents = p.text_extents @text
+      text_extents = painter.text_extents @text
       text_width = text_extents.width
       text_left = @text[0...@cursor_position]
-      text_extents = p.text_extents text_left
+      text_extents = painter.text_extents text_left
       @cursor_rect = Rect.new((5.5_f64 + text_extents.width + @text_translate.x).round.to_i, 5, 1, h - 10)
 
       #puts "recalc_cursor w=#{w} cp=#{@cursor_position}"

--- a/src/ltk/widget_painters/line_edit_painter.cr
+++ b/src/ltk/widget_painters/line_edit_painter.cr
@@ -1,0 +1,79 @@
+module Ltk
+  class LineEditPainter
+    getter line_edit, painter
+
+    delegate ctx, fill_round_rect, font_extents, to: painter
+
+    def initialize(@line_edit : LineEdit, @painter : Painter)
+    end
+
+    def draw
+      focused = line_edit.focused?
+      w = line_edit.width
+      h = line_edit.height
+
+      #ctx.scale 3.0_f64, 3.0_f64
+
+      # Draw Borders
+      if focused
+        ctx.set_source_rgb 83.0_f64 / 255.0_f64, 160.0_f64 / 255.0_f64, 237.0_f64 / 255.0_f64
+      else
+        pattern = Pattern.create_linear 0.0_f64, 0.0_f64, 0.0_f64, h.to_f
+        pattern.add_color_stop 0.0_f64, 46.0_f64 / 255.0_f64, 46.0_f64 / 255.0_f64, 46.0_f64 / 255.0_f64
+        pattern.add_color_stop 1.0_f64, 60.0_f64 / 255.0_f64, 60.0_f64 / 255.0_f64, 60.0_f64 / 255.0_f64
+        ctx.source = pattern
+      end
+      fill_round_rect 0, 0, w, h, 3
+
+      w -= 2; h -= 2
+      if focused
+        ctx.set_source_rgb 48.0_f64 / 255.0_f64, 60.0_f64 / 255.0_f64, 72.0_f64 / 255.0_f64
+      else
+        pattern = Pattern.create_linear 0.0_f64, 0.0_f64, 0.0_f64, h.to_f
+        pattern.add_color_stop 0.0_f64, 50.0_f64 / 255.0_f64, 50.0_f64 / 255.0_f64, 50.0_f64 / 255.0_f64
+        pattern.add_color_stop 1.0_f64, 53.0_f64 / 255.0_f64, 53.0_f64 / 255.0_f64, 53.0_f64 / 255.0_f64
+        ctx.source = pattern
+      end
+      fill_round_rect 1, 1, w, h, 3
+
+      w -= 2; h -= 2
+      ctx.set_source_rgb 56.0_f64 / 255.0_f64, 56.0_f64 / 255.0_f64, 56.0_f64 / 255.0_f64
+      fill_round_rect 2, 2, w, h, 3
+
+      # Clip region for text and cursor
+      w = line_edit.width
+      h = line_edit.height
+      ctx.rectangle(5.0_f64, 0_f64, w - 5.0_f64, h.to_f64)
+      ctx.clip
+
+      # Draw Text
+      text = line_edit.text
+      text_translate = line_edit.text_translate
+
+      extents = ctx.text_extents text
+      x = 5.0_f64 + text_translate.x
+      y = (line_edit.height / 2.0_f64) - (font_extents.height / 2 - font_extents.ascent) + text_translate.y
+
+      ctx.move_to x, y
+
+      ctx.set_source_rgb 0.85_f64, 0.85_f64, 0.85_f64
+      ctx.show_text text
+
+      # Draw Cursor
+      if line_edit.cursor_visible? && line_edit.cursor_position >= 0
+        extents = ctx.text_extents text[0...line_edit.cursor_position]
+        x = 5.5_f64 + extents.width
+        ctx.set_source_rgb 1.0_f64, 1.0_f64, 1.0_f64
+        rect = line_edit.cursor_rect
+        if rect.width > 1
+          puts "rect.width > 0 : #{rect.width}"
+        else
+          ctx.move_to rect.x.to_f64, 4.0_f64
+          ctx.line_to rect.x.to_f64, h.to_f64
+          ctx.line_width = 1.0
+          ctx.stroke
+        end
+      end
+    end
+  end
+end

--- a/src/ltk/widget_painters/line_edit_painter.cr
+++ b/src/ltk/widget_painters/line_edit_painter.cr
@@ -3,19 +3,29 @@ module Ltk
     getter line_edit, painter
 
     delegate ctx, fill_round_rect, font_extents, to: painter
+    delegate focused?, height, text, text_translate, width, to: line_edit
 
     def initialize(@line_edit : LineEdit, @painter : Painter)
     end
 
     def draw
-      focused = line_edit.focused?
-      w = line_edit.width
-      h = line_edit.height
+      draw_borders!
+      clip_region!
+      draw_text!
+      draw_cursor!
+    end
 
-      #ctx.scale 3.0_f64, 3.0_f64
+    # Clip region for text and cursor
+    private def clip_region!
+      ctx.rectangle(5.0_f64, 0_f64, width - 5.0_f64, height.to_f64)
+      ctx.clip
+    end
 
-      # Draw Borders
-      if focused
+    private def draw_borders!
+      w = width
+      h = height
+
+      if focused?
         ctx.set_source_rgb 83.0_f64 / 255.0_f64, 160.0_f64 / 255.0_f64, 237.0_f64 / 255.0_f64
       else
         pattern = Pattern.create_linear 0.0_f64, 0.0_f64, 0.0_f64, h.to_f
@@ -26,7 +36,7 @@ module Ltk
       fill_round_rect 0, 0, w, h, 3
 
       w -= 2; h -= 2
-      if focused
+      if focused?
         ctx.set_source_rgb 48.0_f64 / 255.0_f64, 60.0_f64 / 255.0_f64, 72.0_f64 / 255.0_f64
       else
         pattern = Pattern.create_linear 0.0_f64, 0.0_f64, 0.0_f64, h.to_f
@@ -39,27 +49,9 @@ module Ltk
       w -= 2; h -= 2
       ctx.set_source_rgb 56.0_f64 / 255.0_f64, 56.0_f64 / 255.0_f64, 56.0_f64 / 255.0_f64
       fill_round_rect 2, 2, w, h, 3
+    end
 
-      # Clip region for text and cursor
-      w = line_edit.width
-      h = line_edit.height
-      ctx.rectangle(5.0_f64, 0_f64, w - 5.0_f64, h.to_f64)
-      ctx.clip
-
-      # Draw Text
-      text = line_edit.text
-      text_translate = line_edit.text_translate
-
-      extents = ctx.text_extents text
-      x = 5.0_f64 + text_translate.x
-      y = (line_edit.height / 2.0_f64) - (font_extents.height / 2 - font_extents.ascent) + text_translate.y
-
-      ctx.move_to x, y
-
-      ctx.set_source_rgb 0.85_f64, 0.85_f64, 0.85_f64
-      ctx.show_text text
-
-      # Draw Cursor
+    def draw_cursor!
       if line_edit.cursor_visible? && line_edit.cursor_position >= 0
         extents = ctx.text_extents text[0...line_edit.cursor_position]
         x = 5.5_f64 + extents.width
@@ -69,11 +61,22 @@ module Ltk
           puts "rect.width > 0 : #{rect.width}"
         else
           ctx.move_to rect.x.to_f64, 4.0_f64
-          ctx.line_to rect.x.to_f64, h.to_f64
+          ctx.line_to rect.x.to_f64, height.to_f64
           ctx.line_width = 1.0
           ctx.stroke
         end
       end
+    end
+
+    def draw_text!
+      extents = ctx.text_extents text
+      x = 5.0_f64 + text_translate.x
+      y = (line_edit.height / 2.0_f64) - (font_extents.height / 2 - font_extents.ascent) + text_translate.y
+
+      ctx.move_to x, y
+
+      ctx.set_source_rgb 0.85_f64, 0.85_f64, 0.85_f64
+      ctx.show_text text
     end
   end
 end


### PR DESCRIPTION
Painter is very much tangled with the various widget classes. This PR refactors one of the widget painters in its own class (for LineEdit widget).

## changes

* extract drawing logic for line edit widget into its own class
* refactors the line edit painter into smaller methods
* don't create a new painter each time paint is triggered, instead cache a painter (and the ne painter widget class instance)
* fixes text insertion so that text is inserted where the cursor is placed.

## why

Simplifies the Painter class so it doesn't know about individual widgets, and fixes a bug in the line edit widget.

Once the other widget painters are refactored in this way other optimizations may be made to simplify the code (ie moving common widget painter code to a mixin or  base class) and simplify the code further.
